### PR TITLE
[FIX] mail_recipient_unchecked

### DIFF
--- a/mail_recipient_unchecked/templates/chatter.xml
+++ b/mail_recipient_unchecked/templates/chatter.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="mail.chatter.ChatComposer" t-extend="mail.chatter.ChatComposer">
         <t t-jquery="input[type='checkbox'][t-att-data-fullname='recipient.full_name']" t-operation="attributes">
-            <attribute name="t-att-checked"></attribute>
+            <attribute name="t-att-checked">undefined</attribute>
         </t>
     </t>
 </templates>


### PR DESCRIPTION
When evaluating t-att-checked, Odoo does not interpret the empty string as unchecked.

We get the following exception:
Uncaught Error: QWeb2: Error evaluating template: SyntaxError: Unexpected token )

For the checkbox to be unchecked, the attribute value must be undefined.